### PR TITLE
enable ROS2 usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,16 @@ rosrun catmux create_session package://catmux/etc/example_session.yaml --tmux_co
 If you are not that familiar with tmux: To kill a session, simply type `tmux kill-session` in any
 terminal window. In the `etc/tmux_default.conf` there is a key-binding for that, see
 `etc/readme_tmux.txt` for details.
+
+## Usage ROS2
+Only available in the ros2 branch of this repository!
+
+### Installation
+Very similar to ROS1: simply clone the package into your ROS2-workspace, build it and
+you're done.
+
+### Usage (full blown example)
+In case you are not in the base directory of your ROS2 workspace while running this command, don't forget to set correct paths!
+```
+ros2 run catmux create_session $PWD/src/catmux/etc/example_session.yaml --tmux_config $PWD/src/catmux/etc/tmux_default.conf --session_name example_session --overwrite show_layouts=True,replacement_param="new catmux user"
+```

--- a/package.xml
+++ b/package.xml
@@ -44,19 +44,17 @@
   <!--   <test_depend>gtest</test_depend> -->
   <!-- Use doc_depend for packages you need only for building documentation: -->
   <!--   <doc_depend>doxygen</doc_depend> -->
-  <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>rospy</build_depend>
+  <build_depend>rclpy</build_depend>
   <exec_depend>python-argparse</exec_depend>
-  <exec_depend>python-catkin-pkg</exec_depend>
   <exec_depend>python-yaml</exec_depend>
-  <exec_depend>rospy</exec_depend>
+  <exec_depend>rclpy</exec_depend>
   <exec_depend>tmux</exec_depend>
   <exec_depend>future</exec_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <!-- Other tools can request additional information be placed here -->
-
+    <build_type>ament_python</build_type>
   </export>
 </package>

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script-dir=$base/lib/catmux
+[install]
+install-scripts=$base/lib/catmux

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
-from catkin_pkg.python_setup import generate_distutils_setup
+from setuptools import setup
 
-package_info = generate_distutils_setup(
-    packages=['catmux'],
+package_name = 'catmux'
+
+setup( name=package_name,
+    packages=[package_name],
+    data_files=[
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+    ],
+    install_requires=['setuptools'],
     scripts=['script/create_session'],
     package_dir={'': 'src'}
 )
-
-setup(**package_info)


### PR DESCRIPTION
Converts the package straight forward to be used in a ROS2 workspace with colcon.