### PR TITLE
User PyYAML SafeLoader

### DIFF
--- a/catmux/session.py
+++ b/catmux/session.py
@@ -55,7 +55,7 @@ class Session(object):
         """Initializes the data from a file read from filepath."""
 
         try:
-            self.__yaml_data = yaml.load(open(filepath, 'r'))
+            self.__yaml_data = yaml.safe_load(open(filepath, 'r'))
         except yaml.YAMLError as exc:
             print('Error while loading config file: %s', exc)
             print('Loaded file was: %s', filepath)


### PR DESCRIPTION
This removes the PyYAML warning on execution.
There isn't really any security gained with this change, as the main vulnerability of the unsafe loader, namely executing arbitrary code, is exactly what catmux is made for.
Still, getting rid of the warning is nice and the differences between the loaders (SafeLoader only parses standard YAML tags, while the unsafe Loader can create arbitrary Python objects) are not relevant for catmux.