### PR TITLE
Use own tmux server for catmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ If you are not that familiar with tmux: To kill a session, simply type `tmux kil
 terminal window. In the `etc/tmux_default.conf` there is a key-binding for that, see
 `etc/readme_tmux.txt` for details.
 
+### Tmux server to be used
+By default, catmux spawns its own tmux server called `catmux`. Therefore, a simple
+`tmux list-sessions` (or `tmux ls`) will not list the `catmux` session. To list the `catmux`
+session, use `tmux -L catmux list-sessions`. You can change the server's name by specifying the
+`-L <server_name>` parameter to `catmux_create_session`. That mechanism ensures that the environment
+in which `catmux_create_session` is started, will be used inside the catmux session (as long as no
+other session previously exists on that particular tmux server).
+
 ## Migrating from the catkin version of catmux
 With the spread of ROS2, the need for a catkin-independent catmux has emerged.
 Catmux is now a plain python package without the ROS integration.

--- a/catmux/session.py
+++ b/catmux/session.py
@@ -70,7 +70,7 @@ class Session(object):
         self._parse_parameters()
         self._parse_windows()
 
-    def run(self, debug=False):
+    def run(self, server_name, debug=False):
         """Runs the loaded session"""
         if len(self._windows) == 0:
             print("No windows to run found")
@@ -78,13 +78,16 @@ class Session(object):
 
         first = True
         for window in self._windows:
-            window.create(self._session_name, first)
+            window.create(server_name, self._session_name, first)
             if debug:
                 window.debug()
             first = False
 
+        tmux_wrapper = tmux.TmuxWrapper(server_name)
         if "default_window" in self._common:
-            tmux.tmux_call(["select-window", "-t", self._common["default_window"]])
+            tmux_wrapper.tmux_call(
+                ["select-window", "-t", self._common["default_window"]]
+            )
 
     def _parse_common(self):
         if self.__yaml_data is None:

--- a/catmux/split.py
+++ b/catmux/split.py
@@ -46,7 +46,8 @@ class Split(object):
             print(prefix + "  commands: ")
             print("\t- " + "\n\t- ".join(getattr(self, "commands")))
 
-    def run(self):
+    def run(self, server_name):
         "Executes all configured commands" ""
+        tmux_wrapper = tmux.TmuxWrapper(server_name=server_name)
         for command in getattr(self, "commands"):
-            tmux.send_keys(command)
+            tmux_wrapper.send_keys(command)

--- a/catmux/tmux_wrapper.py
+++ b/catmux/tmux_wrapper.py
@@ -27,23 +27,27 @@
 import subprocess
 
 
-def send_keys(command):
-    """Executes a command in the current tmux pane"""
+class TmuxWrapper:
+    """Wrapper for tmux calls"""
 
-    tmux_call(["send-keys", command, "C-m"])
+    def __init__(self, server_name):
+        self.server_name = server_name
 
+    def send_keys(self, command):
+        """Executes a command in the current tmux pane"""
 
-def split():
-    """Splits the current pane into two"""
-    tmux_call(["split-window"])
+        self.tmux_call(["send-keys", command, "C-m"])
 
+    def split(self):
+        """Splits the current pane into two"""
+        self.tmux_call(["split-window"])
 
-def tmux_call(command_list):
-    """Executes a tmux command"""
-    tmux_cmd = ["tmux"] + command_list
+    def tmux_call(self, command_list):
+        """Executes a tmux command"""
+        tmux_cmd = ["tmux", "-L", self.server_name] + command_list
 
-    # print(' '.join(tmux_cmd))
-    _safe_call(tmux_cmd)
+        # print(' '.join(tmux_cmd))
+        _safe_call(tmux_cmd)
 
 
 def _safe_call(cmd_list):

--- a/catmux/window.py
+++ b/catmux/window.py
@@ -61,22 +61,23 @@ class Window(object):
         for counter, split in enumerate(self.splits):
             split.debug(name=str(counter), prefix=" ")
 
-    def create(self, session_name, first=False):
+    def create(self, server_name, session_name, first=False):
         """Creates the window"""
+        tmux_wrapper = tmux.TmuxWrapper(server_name=server_name)
         if not first:
-            tmux.tmux_call(["new-window"])
-        tmux.tmux_call(["rename-window", getattr(self, "name")])
+            tmux_wrapper.tmux_call(["new-window"])
+        tmux_wrapper.tmux_call(["rename-window", getattr(self, "name")])
         for counter, split in enumerate(self.splits):
             if counter > 0:
-                tmux.split()
+                tmux_wrapper.split()
 
             if hasattr(self, "before_commands"):
                 for cmd in getattr(self, "before_commands"):
-                    tmux.send_keys(cmd)
-            split.run()
+                    tmux_wrapper.send_keys(cmd)
+            split.run(server_name=server_name)
 
         if hasattr(self, "layout"):
-            tmux.tmux_call(["select-layout", getattr(self, "layout")])
+            tmux_wrapper.tmux_call(["select-layout", getattr(self, "layout")])
 
         if hasattr(self, "delay"):
             print(

--- a/script/catmux_create_session
+++ b/script/catmux_create_session
@@ -58,6 +58,9 @@ def parse_arguments(debug=False):
         "-n", "--session_name", default="catmux", help="Name used for the tmux session"
     )
     parser.add_argument(
+        "-L", "--server-name", default="catmux", help="tmux server to use"
+    )
+    parser.add_argument(
         "-t", "--tmux_config", help="This config will be used for the tmux session"
     )
     parser.add_argument(
@@ -84,7 +87,9 @@ def main():
     session_config.init_from_filepath(args.session_config)
 
     try:
-        subprocess.check_call(["tmux", "has-session", "-t", args.session_name])
+        subprocess.check_call(
+            ["tmux", "-t", args.session_name, "has-session", "-L", args.server_name]
+        )
         print(
             'Session with name "{}" already exists. Not overwriting session.'.format(
                 args.session_name
@@ -96,7 +101,7 @@ def main():
         # probably something severely wrong. TODO: This could be done better probably
         pass
 
-    command = ["tmux"]
+    command = ["tmux", "-L", args.server_name]
     if args.tmux_config:
         tmux_config = args.tmux_config
     elif os.path.exists(os.path.expanduser("~/.tmux.conf")):
@@ -118,9 +123,9 @@ def main():
 
     print('Created session "{}"'.format(args.session_name))
 
-    session_config.run()
+    session_config.run(args.server_name)
     if not args.detach:
-        safe_call(["tmux", "attach", "-t", args.session_name])
+        safe_call(["tmux", "-L", args.server_name, "attach", "-t", args.session_name])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Tmux uses the environment where the server is started in. If we already
have a tmux server running when the catmux session is created, that
environment is re-used. The changes from this commit allow setting up
an environment and then start catmux with a new tmux-server that will use
that environment (as long as there is not already a running server with the
given name).