### PR TITLE
Fix session name

### DIFF
--- a/catmux/session.py
+++ b/catmux/session.py
@@ -87,7 +87,11 @@ class Session(object):
         tmux_wrapper = tmux.TmuxWrapper(self._server_name)
         if "default_window" in self._common:
             tmux_wrapper.tmux_call(
-                ["select-window", "-t", self._session_name + ":" + self._common["default_window"]]
+                [
+                    "select-window",
+                    "-t",
+                    self._session_name + ":" + self._common["default_window"],
+                ]
             )
 
     def _parse_common(self):
@@ -122,7 +126,8 @@ class Session(object):
         print(
             " - "
             + "\n - ".join(
-                "{} = {}".format(key, value) for key, value in list(self._parameters.items())
+                "{} = {}".format(key, value)
+                for key, value in list(self._parameters.items())
             )
         )
         if self._runtime_params:
@@ -211,6 +216,8 @@ class Session(object):
 
                 kwargs.update(window)
 
-                self._windows.append(Window(self._server_name, self._session_name, **kwargs))
+                self._windows.append(
+                    Window(self._server_name, self._session_name, **kwargs)
+                )
         else:
             print("No window section found in session config")

--- a/catmux/split.py
+++ b/catmux/split.py
@@ -46,8 +46,8 @@ class Split(object):
             print(prefix + "  commands: ")
             print("\t- " + "\n\t- ".join(getattr(self, "commands")))
 
-    def run(self, server_name):
+    def run(self, server_name, target_window=None):
         "Executes all configured commands" ""
         tmux_wrapper = tmux.TmuxWrapper(server_name=server_name)
         for command in getattr(self, "commands"):
-            tmux_wrapper.send_keys(command)
+            tmux_wrapper.send_keys(command, target_window)

--- a/catmux/tmux_wrapper.py
+++ b/catmux/tmux_wrapper.py
@@ -41,9 +41,9 @@ class TmuxWrapper:
         else:
             self.tmux_call(["send-keys", command, "C-m"])
 
-    def split(self):
+    def split(self, target_window):
         """Splits the current pane into two"""
-        self.tmux_call(["split-window"])
+        self.tmux_call(["split-window", "-t", target_window])
 
     def tmux_call(self, command_list):
         """Executes a tmux command"""

--- a/catmux/tmux_wrapper.py
+++ b/catmux/tmux_wrapper.py
@@ -49,7 +49,7 @@ class TmuxWrapper:
         """Executes a tmux command"""
         tmux_cmd = ["tmux", "-L", self.server_name] + command_list
 
-        print(' '.join(tmux_cmd))
+        # print(' '.join(tmux_cmd))
         _safe_call(tmux_cmd)
 
 

--- a/catmux/tmux_wrapper.py
+++ b/catmux/tmux_wrapper.py
@@ -33,10 +33,13 @@ class TmuxWrapper:
     def __init__(self, server_name):
         self.server_name = server_name
 
-    def send_keys(self, command):
+    def send_keys(self, command, target_window=None):
         """Executes a command in the current tmux pane"""
 
-        self.tmux_call(["send-keys", command, "C-m"])
+        if target_window:
+            self.tmux_call(["send-keys", "-t", target_window, command, "C-m"])
+        else:
+            self.tmux_call(["send-keys", command, "C-m"])
 
     def split(self):
         """Splits the current pane into two"""
@@ -46,7 +49,7 @@ class TmuxWrapper:
         """Executes a tmux command"""
         tmux_cmd = ["tmux", "-L", self.server_name] + command_list
 
-        # print(' '.join(tmux_cmd))
+        print(' '.join(tmux_cmd))
         _safe_call(tmux_cmd)
 
 

--- a/catmux/window.py
+++ b/catmux/window.py
@@ -75,11 +75,11 @@ class Window(object):
         )
         for counter, split in enumerate(self.splits):
             if counter > 0:
-                tmux_wrapper.split()
+                tmux_wrapper.split(target_window)
 
             if hasattr(self, "before_commands"):
                 for cmd in getattr(self, "before_commands"):
-                    tmux_wrapper.send_keys(cmd)
+                    tmux_wrapper.send_keys(cmd, target_window=target_window)
             split.run(server_name=self.server_name, target_window=target_window)
 
         if hasattr(self, "layout"):

--- a/catmux/window.py
+++ b/catmux/window.py
@@ -83,7 +83,9 @@ class Window(object):
             split.run(server_name=self.server_name, target_window=target_window)
 
         if hasattr(self, "layout"):
-            tmux_wrapper.tmux_call(["select-layout", "-t", target_window, getattr(self, "layout")])
+            tmux_wrapper.tmux_call(
+                ["select-layout", "-t", target_window, getattr(self, "layout")]
+            )
 
         if hasattr(self, "delay"):
             print(

--- a/script/catmux_create_session
+++ b/script/catmux_create_session
@@ -51,12 +51,18 @@ def safe_call(cmd_list):
 def parse_arguments(debug=False):
     """Parse command line arguments"""
     parser = argparse.ArgumentParser(description="Create a new catmux session")
-    parser.add_argument("session_config", help="Session configuration. Should be a yaml-file.")
+    parser.add_argument(
+        "session_config", help="Session configuration. Should be a yaml-file."
+    )
     parser.add_argument(
         "-n", "--session_name", default="catmux", help="Name used for the tmux session"
     )
-    parser.add_argument("-L", "--server-name", default="catmux", help="tmux server to use")
-    parser.add_argument("-t", "--tmux_config", help="This config will be used for the tmux session")
+    parser.add_argument(
+        "-L", "--server-name", default="catmux", help="tmux server to use"
+    )
+    parser.add_argument(
+        "-t", "--tmux_config", help="This config will be used for the tmux session"
+    )
     parser.add_argument(
         "-d", "--detach", action="store_true", help="Start session in detached mode"
     )
@@ -78,7 +84,9 @@ def main():
     args = parse_arguments()
 
     session_config = CatmuxSession(
-        server_name=args.server_name, session_name=args.session_name, runtime_params=args.overwrite
+        server_name=args.server_name,
+        session_name=args.session_name,
+        runtime_params=args.overwrite,
     )
     session_config.init_from_filepath(args.session_config)
 

--- a/script/catmux_create_session
+++ b/script/catmux_create_session
@@ -51,18 +51,12 @@ def safe_call(cmd_list):
 def parse_arguments(debug=False):
     """Parse command line arguments"""
     parser = argparse.ArgumentParser(description="Create a new catmux session")
-    parser.add_argument(
-        "session_config", help="Session configuration. Should be a yaml-file."
-    )
+    parser.add_argument("session_config", help="Session configuration. Should be a yaml-file.")
     parser.add_argument(
         "-n", "--session_name", default="catmux", help="Name used for the tmux session"
     )
-    parser.add_argument(
-        "-L", "--server-name", default="catmux", help="tmux server to use"
-    )
-    parser.add_argument(
-        "-t", "--tmux_config", help="This config will be used for the tmux session"
-    )
+    parser.add_argument("-L", "--server-name", default="catmux", help="tmux server to use")
+    parser.add_argument("-t", "--tmux_config", help="This config will be used for the tmux session")
     parser.add_argument(
         "-d", "--detach", action="store_true", help="Start session in detached mode"
     )
@@ -83,7 +77,9 @@ def main():
     """Creates a new tmux session if it does not yet exist"""
     args = parse_arguments()
 
-    session_config = CatmuxSession(args.session_name, args.overwrite)
+    session_config = CatmuxSession(
+        server_name=args.server_name, session_name=args.session_name, runtime_params=args.overwrite
+    )
     session_config.init_from_filepath(args.session_config)
 
     try:
@@ -123,7 +119,7 @@ def main():
 
     print('Created session "{}"'.format(args.session_name))
 
-    session_config.run(args.server_name)
+    session_config.run()
     if not args.detach:
         safe_call(["tmux", "-L", args.server_name, "attach", "-t", args.session_name])
 


### PR DESCRIPTION
Allow setting a specific session name and use that everywhere. This enables having other tmux (or catmux) sessions run in parallel while starting a catmux session.