### PR TITLE
Remove unnecessary imports

### DIFF
--- a/script/catmux_create_session
+++ b/script/catmux_create_session
@@ -27,10 +27,7 @@
 from __future__ import print_function
 import os
 import subprocess
-import site
 import sys
-
-import rospkg
 
 import argparse
 


### PR DESCRIPTION
On a fresh install I got `ModuleNotFoundError: No module named 'rospkg'`. Removing `import rospkg` fixed this issue.