### PR TITLE
Correct handling if no parameter in common is set

### DIFF
--- a/catmux/session.py
+++ b/catmux/session.py
@@ -85,7 +85,7 @@ class Session(object):
             first = False
 
         tmux_wrapper = tmux.TmuxWrapper(self._server_name)
-        if "default_window" in self._common:
+        if self._common is not None and "default_window" in self._common:
             tmux_wrapper.tmux_call(
                 [
                     "select-window",
@@ -211,7 +211,7 @@ class Session(object):
                         )
 
                 kwargs = dict()
-                if "before_commands" in self._common:
+                if self._common is not None and "before_commands" in self._common:
                     kwargs["before_commands"] = self._common["before_commands"]
 
                 kwargs.update(window)


### PR DESCRIPTION
This pull request checks if common was parsed correctly and is not None before addressing it.
Currently the script tries to verify if for example a before command is set by accessing the common tag. However this fails if no other sub param of the common tag was set, since it is None in this case