### PR TITLE
Add a colon to the end of the target session when creating windows

### DIFF
--- a/catmux/window.py
+++ b/catmux/window.py
@@ -77,7 +77,7 @@ class Window(object):
         tmux_wrapper = tmux.TmuxWrapper(server_name=self.server_name)
         target_window = ":".join([self.session_name, getattr(self, "name")])
         if not first:
-            tmux_wrapper.tmux_call(["new-window", "-t", self.session_name])
+            tmux_wrapper.tmux_call(["new-window", "-t", self.session_name + ":"])
         tmux_wrapper.tmux_call(
             ["rename-window", "-t", f"{self.session_name}:$", getattr(self, "name")]
         )

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -57,11 +57,11 @@ parameters:
     show_layouts: true
 
 windows:
-    - name: foo
+    - name: foobar
       if: show_layouts
       commands:
         - echo "${replacement_param}"
-    - name: bar
+    - name: hello
       layout: tiled
       delay: 1
       splits:
@@ -71,23 +71,23 @@ windows:
           - echo "second_split"
 """
     server_name = "my_server"
-    session_name = "my_session"
+    session_name = "foo"
     session = Session(server_name=server_name, session_name=session_name)
     session.init_from_yaml(yaml.safe_load(CONFIG))
 
     session.run(debug=True)
     calls = [
-        ["rename-window", "-t", "my_session:$", "foo"],
-        ["send-keys", "-t", "my_session:foo", 'echo "hello"', "C-m"],
-        ["send-keys", "-t", "my_session:foo", 'echo "world"', "C-m"],
-        ["send-keys", "-t", "my_session:foo", 'echo "schubidoo"', "C-m"],
-        ["select-window", "-t", "my_session:foobar"],
-        ["new-window", "-t", "my_session"],
-        ["rename-window", "-t", "my_session:$", "bar"],
-        ["send-keys", "-t", "my_session:bar", 'echo "first_split"', "C-m"],
-        ["split-window", "-t", "my_session:bar"],
-        ["send-keys", "-t", "my_session:bar", 'echo "second_split"', "C-m"],
-        ["select-layout", "-t", "my_session:bar", "tiled"],
+        ["rename-window", "-t", "foo:$", "foobar"],
+        ["send-keys", "-t", "foo:foobar", 'echo "hello"', "C-m"],
+        ["send-keys", "-t", "foo:foobar", 'echo "world"', "C-m"],
+        ["send-keys", "-t", "foo:foobar", 'echo "schubidoo"', "C-m"],
+        ["select-window", "-t", "foo:foobar"],
+        ["new-window", "-t", "foo:"],
+        ["rename-window", "-t", "foo:$", "hello"],
+        ["send-keys", "-t", "foo:hello", 'echo "first_split"', "C-m"],
+        ["split-window", "-t", "foo:hello"],
+        ["send-keys", "-t", "foo:hello", 'echo "second_split"', "C-m"],
+        ["select-layout", "-t", "foo:hello", "tiled"],
     ]
     for call in calls:
         mock_popen.assert_any_call(["tmux", "-L", server_name] + call)


### PR DESCRIPTION
Otherwise the target might get interpreted wrong resulting in the window not being created.

Fixes #37 