### PR TITLE
update supported python versions

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -12,11 +12,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
     name: Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -12,11 +12,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
     name: Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Python 3.8 is now EOL, while Python 3.13 has been released